### PR TITLE
etcd lb doesn't work with HTTP

### DIFF
--- a/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_fedora_atomic_v1/templates/kubecluster.yaml
@@ -326,7 +326,7 @@ resources:
     properties:
       fixed_subnet: {get_attr: [network, fixed_subnet]}
       external_network: {get_param: external_network}
-      protocol: HTTP
+      protocol: {get_param: loadbalancing_protocol}
       port: 2379
 
   ######################################################################


### PR DESCRIPTION
The etcd service doesn't work with HTTP, can we backport this change to ocata