### PR TITLE
Fix k8s_coreos_v1 template incorrect yaml

### DIFF
--- a/magnum/drivers/k8s_coreos_v1/templates/kubecluster.yaml
+++ b/magnum/drivers/k8s_coreos_v1/templates/kubecluster.yaml
@@ -294,7 +294,7 @@ parameters:
     hidden: true
     description: The OpenStack CA certificate to install on the node.
 
- nodes_affinity_policy:
+  nodes_affinity_policy:
     type: string
     description: >
       affinity policy for nodes server group


### PR DESCRIPTION
FYI!

`
Feb 16 10:37:06 ctr01 magnum-conductor[4780]: 2018-02-16 10:37:06.744 4780 ERROR oslo_messaging.rpc.server [req-6ea8de4b-09df-4821-a78f-c77516e78385 - - - - -] Exception during message handling: CommandError: Error parsing template file:///var/lib/magnum/env/lib/python2.7/site-packages/magnum/drivers/k8s_coreos_v1/templates/kubecluster.yaml while parsing a block mapping
Feb 16 10:37:06 ctr01 magnum-conductor[4780]:   in "<unicode string>", line 1, column 1:
Feb 16 10:37:06 ctr01 magnum-conductor[4780]:     heat_template_version: 2014-10-16
Feb 16 10:37:06 ctr01 magnum-conductor[4780]:     ^
Feb 16 10:37:06 ctr01 magnum-conductor[4780]: expected <block end>, but found '<block mapping start>'
Feb 16 10:37:06 ctr01 magnum-conductor[4780]:   in "<unicode string>", line 297, column 2:
Feb 16 10:37:06 ctr01 magnum-conductor[4780]:      nodes_affinity_policy:
Feb 16 10:37:06 ctr01 magnum-conductor[4780]:      ^

`