### PR TITLE
Fix: add missing RBAC permissions to cluster-autoscaler-role

### DIFF
--- a/magnum/drivers/common/templates/kubernetes/fragments/enable-auto-scaling.sh
+++ b/magnum/drivers/common/templates/kubernetes/fragments/enable-auto-scaling.sh
@@ -50,7 +50,7 @@ rules:
     verbs: ["create"]
   # read-only access to cluster state
   - apiGroups: [""]
-    resources: ["services", "replicationcontrollers", "persistentvolumes", "persistentvolumeclaims"]
+    resources: ["namespaces", "services", "replicationcontrollers", "persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["daemonsets", "replicasets"]
@@ -65,7 +65,7 @@ rules:
     resources: ["poddisruptionbudgets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses", "csinodes"]
+    resources: ["storageclasses", "csinodes", "csidrivers", "csistoragecapacities"]
     verbs: ["get", "list", "watch"]
   # misc access
   - apiGroups: [""]


### PR DESCRIPTION
Without these RBAC permissions seeing below in the pod logs:

```
E1024 14:31:11.976758       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1.CSIDriver: failed to list *v1.CSIDriver: csidrivers.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler-account" cannot list resource "csidrivers" in API group "storage.k8s.io" at the cluster scope
E1024 14:31:29.198925       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1beta1.CSIStorageCapacity: failed to list *v1beta1.CSIStorageCapacity: csistoragecapacities.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler-account" cannot list resource "csistoragecapacities" in API group "storage.k8s.io" at the cluster scope
```